### PR TITLE
Exclude merge commits from target branches after reviews when flaggin…

### DIFF
--- a/src/main/java/com/capitalone/dashboard/evaluator/CodeReviewEvaluator.java
+++ b/src/main/java/com/capitalone/dashboard/evaluator/CodeReviewEvaluator.java
@@ -285,7 +285,7 @@ public class CodeReviewEvaluator extends Evaluator<CodeReviewAuditResponseV2> {
         if(CollectionUtils.isEmpty(commitsRelatedToPr)) { return; }
 
         long lastReviewTimestamp = reviewsRelatedToPr.get(reviewsRelatedToPr.size() - 1).getUpdatedAt();
-        List<Commit> commitsAfterPrReviews = commitsRelatedToPr.stream().filter(commit -> (
+        List<Commit> commitsAfterPrReviews = commitsRelatedToPr.stream().filter(Objects::nonNull).filter(commit -> (
                 commit.getScmCommitTimestamp() > lastReviewTimestamp
                 && !isMergeCommitFromTargetBranch(commit, pr))
         ).collect(Collectors.toList());


### PR DESCRIPTION
Exclude merge commits from target branches after reviews when flagging commits after reviews.
Merge commits from target branches are not considered violations; merge commits from non-target branches are considered violations.