### PR TITLE
Log all requests to audit_request collection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <properties>
         <repository.name>api-audit</repository.name>
         <java.version>1.8</java.version>
-        <com.capitalone.dashboard.core.version>3.7.11</com.capitalone.dashboard.core.version>
+        <com.capitalone.dashboard.core.version>3.9.8</com.capitalone.dashboard.core.version>
         <bc.version>3.0.2</bc.version>
         <application.version.number>${version}</application.version.number>
         <apache.rat.plugin.version>0.13</apache.rat.plugin.version>

--- a/src/main/java/com/capitalone/dashboard/ApiSettings.java
+++ b/src/main/java/com/capitalone/dashboard/ApiSettings.java
@@ -1,11 +1,14 @@
 package com.capitalone.dashboard;
 
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 @ConfigurationProperties
@@ -49,6 +52,8 @@ public class ApiSettings {
     private List<String> buildStageRegEx;
     private List<String> ldapdnCheckIgnoredAuthorTypes = new ArrayList<>();
     private String thirdPartyRegex;
+
+    private List<String> ignoreEndPoints = new ArrayList();
 
     public String getKey() {
         return key;
@@ -240,5 +245,15 @@ public class ApiSettings {
 
     public void setThirdPartyRegex(String thirdPartyRegex) {
         this.thirdPartyRegex = thirdPartyRegex;
+    }
+
+    public List<String> getIgnoreEndPoints() { return ignoreEndPoints; }
+
+    public void setIgnoreEndPoints(List<String> ignoreEndPoints) { this.ignoreEndPoints = ignoreEndPoints; }
+
+    public boolean checkIgnoreEndPoint(String endPointURI) {
+        if(CollectionUtils.isEmpty(this.ignoreEndPoints)) return false;
+        List<String> matchingElements  = ignoreEndPoints.parallelStream().filter (str -> StringUtils.containsAny(endPointURI, str)).collect(Collectors.toList());
+        return CollectionUtils.isNotEmpty(matchingElements);
     }
 }

--- a/src/main/java/com/capitalone/dashboard/evaluator/ArtifactEvaluator.java
+++ b/src/main/java/com/capitalone/dashboard/evaluator/ArtifactEvaluator.java
@@ -116,10 +116,8 @@ public class ArtifactEvaluator extends Evaluator<ArtifactAuditResponse> {
     }
 
     private boolean isThirdParty(String repoName) {
-        if(StringUtils.isNotEmpty(repoName)){
-            return Pattern.compile(apiSettings.getThirdPartyRegex()).matcher(repoName).matches();
-        }
-        return false;
+        if(StringUtils.isEmpty(apiSettings.getThirdPartyRegex()) || StringUtils.isEmpty(repoName)) return false;
+        return Pattern.compile(apiSettings.getThirdPartyRegex()).matcher(repoName).matches();
     }
 
     private ArtifactAuditResponse getErrorResponse(CollectorItem collectorItem, ArtifactAuditResponse errorAuditResponse, ArtifactAuditStatus artifactAuditStatus) {


### PR DESCRIPTION
- Feature to enable logging of all requests to `audit_request` collection.
- `apiUser` passed in header is now logged in as part of audit_request capture.