### PR TITLE
match name of created properties file to expected

### DIFF
--- a/docker/properties-builder.sh
+++ b/docker/properties-builder.sh
@@ -16,7 +16,7 @@ echo "SPRING_DATA_MONGODB_HOST: $SPRING_DATA_MONGODB_HOST"
 echo "SPRING_DATA_MONGODB_PORT: $SPRING_DATA_MONGODB_PORT"
 
 
-cat > config/hygieia-api-audit.properties <<EOF
+cat > config/application.properties <<EOF
 #Database Name - default is test
 dbname=${SPRING_DATA_MONGODB_DATABASE:-dashboarddb}
 


### PR DESCRIPTION
docker command expects the configuration file to be named "application.properties". Change name of the output file from properties-builder.sh to match what is expected
