### PR TITLE
start api-audit.jar only in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN mkdir /hygieia/config
 EXPOSE 8081
 
 ENV PROP_FILE /hygieia/config/application.properties
+ENV PROJ_JAR api-audit.jar
 
 WORKDIR /hygieia
 
@@ -14,4 +15,4 @@ COPY target/*.jar /hygieia/
 COPY docker/properties-builder.sh /hygieia/
 
 CMD ./properties-builder.sh &&\
-  java -Djava.security.egd=file:/dev/./urandom -jar *.jar --spring.config.location=$PROP_FILE
+  java -Djava.security.egd=file:/dev/./urandom -jar $PROJ_JAR --spring.config.location=$PROP_FILE


### PR DESCRIPTION
Fixes #87 - current docker image has multiple jars and attempts to start them all which results in fail to start with not all jars present having main manifest attribute.

I don't know the use case for having other jars (source and javadoc) in the container, so leaving them in, just won't start them automatically on container boot.