### PR TITLE
revert version 3.7.7 - strict audit by altIdentifier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <artifactId>api-audit</artifactId>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
-    <version>3.7.9-SNAPSHOT</version>
+    <version>3.7.10-SNAPSHOT</version>
     <description>Hygieia Audit Rest API Layer</description>
     <url>https://github.com/Hygieia/${repository.name}</url>
 

--- a/src/main/java/com/capitalone/dashboard/evaluator/Evaluator.java
+++ b/src/main/java/com/capitalone/dashboard/evaluator/Evaluator.java
@@ -71,10 +71,8 @@ public abstract class Evaluator<T> {
             Optional<ObjectId> componentIdOpt = dashboard.getApplication().getComponents().stream().findFirst().map(Component::getId);
             Optional<Component> componentOpt = componentIdOpt.isPresent() ? Optional.ofNullable(componentRepository.findOne(componentIdOpt.get())) : Optional.empty();
             List<ObjectId> collectorItemIds = componentOpt.map(component ->
-                    component.getCollectorItems(collectorType).stream().filter(Objects::nonNull)
-                            .filter(c-> StringUtils.isNotEmpty(c.getAltIdentifier()))
-                            .filter(c -> ConversionUtils.matchAltIdentifier(c, altIdentifier)).map(CollectorItem::getId).collect(Collectors.toList())).orElse(Collections.emptyList());
-            return CollectionUtils.isNotEmpty(collectorItemIds) ? IterableUtils.toList(collectorItemRepository.findAll(collectorItemIds)) : Collections.emptyList();
+                    component.getCollectorItems(collectorType).stream().filter(c -> isEqualsAltIdentifier(c, altIdentifier)).map(CollectorItem::getId).collect(Collectors.toList())).orElse(Collections.emptyList());
+            return CollectionUtils.isNotEmpty(collectorItemIds) ? IterableUtils.toList(collectorItemRepository.findAll(collectorItemIds)) : getCollectorItems(dashboard,collectorType);
         }
         else{
             return getCollectorItems(dashboard,collectorType);
@@ -111,6 +109,10 @@ public abstract class Evaluator<T> {
         return c.getOptions().get(TEST_TYPE).equals(testType);
     }
 
+    private boolean isEqualsAltIdentifier(CollectorItem c,String altIdentifier) {
+        if (Objects.isNull(c.getAltIdentifier())) return false;
+        return c.getAltIdentifier().equalsIgnoreCase(altIdentifier);
+    }
 
     private boolean isEqualsIdentifierName(CollectorItem c, String identifierName) {
         return (Objects.nonNull(identifierName) && Objects.nonNull(c.getOptions())) ? identifierName.equalsIgnoreCase((String)c.getOptions().get(ARTIFACT_NAME)) : false;


### PR DESCRIPTION
revert version 3.7.7 - strict audit by altIdentifier as part of docdb migration